### PR TITLE
Don't try to start Sauce Connect from Karma

### DIFF
--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -91,6 +91,7 @@ module.exports = (config) ->
     # sauce labs config
     sauceLabs:
       testName: 'Karma and Sauce Labs demo'
+      startConnect: !process.env.TRAVIS
 
     customLaunchers: customLaunchers
 


### PR DESCRIPTION
When running on TravisCI, running two tunnels won't work by default.

So, when we're on Travis' infrastructure, don't start Sauce Connect from Karma.  Use the 'TRAVIS' environment variable to determine if we're on Travis.